### PR TITLE
add travis with updated rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+
+rvm:
+  - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
+script: rake spec
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/cld2.gemspec
+++ b/cld2.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "ffi", "~> 1.9.3"
 
-  gem.add_development_dependency "rspec", "~> 2.14.1"
+  gem.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Adds travis.yml file for testing ruby versions.
Adds 2.4, 2.5, 2.6 and ruby-head
cc @zendesk/classic-upgrade 